### PR TITLE
Fixes for discovery

### DIFF
--- a/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
@@ -20,7 +20,7 @@ namespace ASCOM.Alpaca.Discovery
         private readonly ILogger logger; // Optional logger
         private int discoveryPort = Constants.DiscoveryPort; // Default to the standard discovery port
         private readonly UdpClient iPv4Client; // UDP client to send and listen for IPv4 broadcasts
-        private readonly Dictionary<IPAddress, UdpClient> IPv6Clients = new Dictionary<IPAddress, UdpClient>(); // Colleciton of IP v6 clients for the various link local and localhost networks
+        private readonly Dictionary<IPAddress, UdpClient> IPv6Clients = new Dictionary<IPAddress, UdpClient>(); // Collection of IP v6 clients for the various link local and localhost networks
         private bool disposedValue; // Disposed variable
 
         #region Initialisation and Dispose
@@ -39,7 +39,7 @@ namespace ASCOM.Alpaca.Discovery
                 MulticastLoopback = false
             };
 
-            // 0 tells OS to give us a free ethereal port
+            // 0 tells OS to give us a free ephemeral port
             iPv4Client.Client.Bind(new IPEndPoint(IPAddress.Any, 0));
             iPv4Client.BeginReceive(ReceiveCallback, iPv4Client);
         }
@@ -346,7 +346,7 @@ namespace ASCOM.Alpaca.Discovery
         {
             var client = new UdpClient(AddressFamily.InterNetworkV6);
 
-            //0 tells OS to give us a free ethereal port
+            //0 tells OS to give us a free ephemeral port
             client.Client.Bind(new IPEndPoint(host, port));
 
             client.BeginReceive(ReceiveCallback, client);

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
@@ -23,6 +23,8 @@ namespace ASCOM.Alpaca.Discovery
         private readonly Dictionary<IPAddress, UdpClient> IPv6Clients = new Dictionary<IPAddress, UdpClient>(); // Collection of IP v6 clients for the various link local and localhost networks
         private bool disposedValue; // Disposed variable
 
+        private const int SIO_UDP_CONNRESET = -1744830452; //Control code to turn off UDP ICMP Connection Reset
+
         #region Initialisation and Dispose
 
         /// <summary>
@@ -289,8 +291,7 @@ namespace ASCOM.Alpaca.Discovery
 
             //Fix for ICMP Reset
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                int SIO_UDP_CONNRESET = -1744830452;
+            { 
                 client.Client.IOControl((IOControlCode)SIO_UDP_CONNRESET, new byte[] { 0, 0, 0, 0 }, null);
             }
 

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
@@ -250,7 +250,7 @@ namespace ASCOM.Alpaca.Discovery
 
                                     if (!IPv4Clients.ContainsKey(uni.Address))
                                     {
-                                        IPv4Clients.Add(uni.Address, NewIPv4Client(uni.Address));
+                                        IPv4Clients.Add(uni.Address, NewIPv4Client());
                                     }
 
                                     if (!IPv4Clients[uni.Address].Client.IsBound)
@@ -280,7 +280,7 @@ namespace ASCOM.Alpaca.Discovery
         }
 
 
-        private UdpClient NewIPv4Client(IPAddress host)
+        private UdpClient NewIPv4Client()
         {
             var client = new UdpClient();
 

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/Finder.cs
@@ -163,7 +163,7 @@ namespace ASCOM.Alpaca.Discovery
                 LogMessage($"ReceiveCallback", $"Received {ReceiveString} from Alpaca device at {endpoint.Address}");
 
                 // Configure the UdpClient class to accept more messages, if they arrive
-                udpClient.BeginReceive(ReceiveCallback, udpClient);
+                udpClient.BeginReceive(new AsyncCallback(ReceiveCallback), udpClient);
 
                 // Accept responses containing the discovery response string and don't respond to your own transmissions
                 if (ReceiveString.ToLowerInvariant().Contains(Constants.ResponseString.ToLowerInvariant())) // Accept responses in any casing so that bad casing can be reported
@@ -375,7 +375,7 @@ namespace ASCOM.Alpaca.Discovery
             //0 tells OS to give us a free ephemeral port
             client.Client.Bind(new IPEndPoint(host, port));
 
-            client.BeginReceive(ReceiveCallback, client);
+            client.BeginReceive(new AsyncCallback(ReceiveCallback), client);
 
             return client;
         }


### PR DESCRIPTION
This fixes some typos, switches over to using an IPv4 or IPv6 UDP client per interface, uses AsyncCallback, blocks discovery on interfaces that are router only and disables ICMP reset (if one is received). It also always restarts discovery, even if an error occurs while reading the packet.