### PR TITLE
Create ITraceLogger interface

### DIFF
--- a/ASCOM.Alpaca.Device/NameSpaceDoc.cs
+++ b/ASCOM.Alpaca.Device/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Alpaca.Device
+﻿namespace ASCOM.Alpaca.Device
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaCamera.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaCamera.cs
@@ -1,18 +1,13 @@
 ﻿using ASCOM.Common;
 using ASCOM.Common.Alpaca;
 using ASCOM.Common.DeviceInterfaces;
-using ASCOM.Common.Helpers;
 using ASCOM.Common.Interfaces;
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
-using System.Net;
 using System.Net.Http;
 using System.Reflection;
-using System.Threading.Tasks;
 
 namespace ASCOM.Alpaca.Clients
 {

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaFilterWheel.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaFilterWheel.cs
@@ -3,7 +3,6 @@ using ASCOM.Common.Alpaca;
 using ASCOM.Common.DeviceInterfaces;
 using ASCOM.Common.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace ASCOM.Alpaca.Clients

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaObservingConditions.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaObservingConditions.cs
@@ -3,7 +3,6 @@ using ASCOM.Common.Alpaca;
 using ASCOM.Common.DeviceInterfaces;
 using ASCOM.Common.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace ASCOM.Alpaca.Clients

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaSafetyMonitor.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaSafetyMonitor.cs
@@ -3,7 +3,6 @@ using ASCOM.Common.Alpaca;
 using ASCOM.Common.DeviceInterfaces;
 using ASCOM.Common.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace ASCOM.Alpaca.Clients

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaSwitch.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/AlpacaSwitch.cs
@@ -3,7 +3,6 @@ using ASCOM.Common.Alpaca;
 using ASCOM.Common.DeviceInterfaces;
 using ASCOM.Common.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace ASCOM.Alpaca.Clients

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/BaseClass/ClientConfiguration.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/AlpacaDevices/BaseClass/ClientConfiguration.cs
@@ -2,8 +2,6 @@
 using ASCOM.Common.Interfaces;
 using ASCOM.Common;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace ASCOM.Alpaca.Clients
 {

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/DynamicClientDriver.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/DynamicClientDriver.cs
@@ -3,7 +3,6 @@ using ASCOM.Common.Alpaca;
 using ASCOM.Common.Com;
 using ASCOM.Common.DeviceInterfaces;
 using ASCOM.Common.Interfaces;
-using ASCOM.Tools;
 
 using System;
 using System.Collections.Concurrent;
@@ -15,7 +14,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Clients/NameSpaceDoc.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Clients/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Alpaca.Clients
+﻿namespace ASCOM.Alpaca.Clients
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/AlpacaDiscovery.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/AlpacaDiscovery.cs
@@ -1,8 +1,6 @@
-﻿using ASCOM.Alpaca.Clients;
-using ASCOM.Common;
+﻿using ASCOM.Common;
 using ASCOM.Common.Alpaca;
 using ASCOM.Common.Interfaces;
-using ASCOM.Tools;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -47,7 +45,7 @@ namespace ASCOM.Alpaca.Discovery
         internal const int NUMBER_OF_THREAD_MESSAGE_INDENT_SPACES = 2;
 
         // Utility objects
-        private readonly TraceLogger TL;
+        private readonly ITraceLogger traceLogger;
         private Finder finder;
         private Timer discoveryCompleteTimer;
         private HttpClient httpClient;
@@ -81,9 +79,9 @@ namespace ASCOM.Alpaca.Discovery
         /// </summary>
         /// <param name="strictCasing">Trace logger instance to use for activity logging</param>
         /// <param name="traceLogger">Trace logger instance to use for activity logging</param>
-        public AlpacaDiscovery(bool strictCasing, TraceLogger traceLogger)
+        public AlpacaDiscovery(bool strictCasing, ITraceLogger traceLogger)
         {
-            TL = traceLogger; // Save the supplied trace logger object
+            this.traceLogger = traceLogger; // Save the supplied trace logger object
             this.strictCasing = strictCasing;
             InitialiseClass(); // Initialise using the trace logger
         }
@@ -105,8 +103,8 @@ namespace ASCOM.Alpaca.Discovery
                 }
 
                 // Get a new broadcast response finder
-                //finder = new Finder(FoundDeviceEventHandler, strictCasing,TL);
-                finder = new Finder(strictCasing, TL);
+                //finder = new Finder(FoundDeviceEventHandler, strictCasing,traceLogger);
+                finder = new Finder(strictCasing, traceLogger);
                 finder.ResponseReceivedEvent += FoundDeviceEventHandler;
 
                 LogMessage("AlpacaDiscoveryInitialise", $"Complete - Running on thread {Thread.CurrentThread.ManagedThreadId}");
@@ -654,7 +652,7 @@ namespace ASCOM.Alpaca.Discovery
         /// <param name="message"></param>
         private void LogMessage(string methodName, string message)
         {
-            TL?.Log(LogLevel.Information, $"AlpacaDiscovery - {methodName} - {Thread.CurrentThread.ManagedThreadId,2} {message}");
+            traceLogger?.Log(LogLevel.Information, $"AlpacaDiscovery - {methodName} - {Thread.CurrentThread.ManagedThreadId,2} {message}");
         }
 
         #endregion

--- a/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/NameSpaceDoc.cs
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.Discovery/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Alpaca.Discovery
+﻿namespace ASCOM.Alpaca.Discovery
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Alpaca/ASCOM.Alpaca.csproj
+++ b/ASCOM.Alpaca/ASCOM.Alpaca.csproj
@@ -51,7 +51,6 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\ASCOM.Common\ASCOM.Common.csproj" />
-		<ProjectReference Include="..\ASCOM.Tools\ASCOM.Tools.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/ASCOM.Com/ASCOM.Com.DriverAccess/NameSpaceDoc.cs
+++ b/ASCOM.Com/ASCOM.Com.DriverAccess/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Com.DriverAccess
+﻿namespace ASCOM.Com.DriverAccess
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Com/ASCOM.Com.csproj
+++ b/ASCOM.Com/ASCOM.Com.csproj
@@ -37,7 +37,6 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\ASCOM.Common\ASCOM.Common.csproj" />
-		<ProjectReference Include="..\ASCOM.Tools\ASCOM.Tools.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/ASCOM.Com/Chooser.cs
+++ b/ASCOM.Com/Chooser.cs
@@ -1,9 +1,7 @@
 ﻿using ASCOM.Common;
 using ASCOM.Common.Interfaces;
 using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace ASCOM.Com
 {

--- a/ASCOM.Com/NameSpaceDoc.cs
+++ b/ASCOM.Com/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Com
+﻿namespace ASCOM.Com
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Com/PlatformUtilities.cs
+++ b/ASCOM.Com/PlatformUtilities.cs
@@ -1,17 +1,12 @@
-﻿using ASCOM.Common.Interfaces;
-using ASCOM.Tools;
-using Microsoft.Win32;
+﻿using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Text;
-using static System.Net.Mime.MediaTypeNames;
 using System.Threading;
-using System.Runtime.CompilerServices;
 using System.IO;
 using static System.Environment;
 using ASCOM.Common;
+using ASCOM.Common.Interfaces;
 
 namespace ASCOM.Com
 {
@@ -45,15 +40,18 @@ namespace ASCOM.Com
 
         // Variables
         private static Version platformVersion = null;
-        private static readonly TraceLogger TL;
         private static bool driverGenerationComplete;
+
+        /// <summary>
+        /// Static field (locator pattern) that assigns an ITraceLogger for use in PlatformUtilities.
+        /// </summary>
+        public static ITraceLogger TraceLogger = new NullLogger();
 
         #region Initialise
 
         static PlatformUtilities()
         {
             string platformVersionString;
-            TL = new TraceLogger("PlatformUtilities", true);
 
             // Populate the Platform version variable when the class is initialised
 
@@ -214,7 +212,7 @@ namespace ASCOM.Com
             // Create a version object from the supplied major and minor required version numbers
             requiredVersion = new Version(requiredMajorVersion, requiredMinorVersion, requiredServicePack, requiredBuild);
 
-            TL.LogMessage("IsMinimumRequiredVersion", $"platformVersion: {platformVersion}, Required version: {requiredVersion}");
+            TraceLogger.LogMessage("IsMinimumRequiredVersion", $"platformVersion: {platformVersion}, Required version: {requiredVersion}");
 
             // Compare the two versions and respond accordingly
             if (platformVersion >= requiredVersion)
@@ -267,7 +265,7 @@ namespace ASCOM.Com
             {
                 // Create a new Alpaca driver of the current ASCOM device type
                 newProgId = CreateNewAlpacaDriver(deviceType, description);
-                TL.LogMessage("CreateDynamicDriver", $"Device type: {deviceType}, newProgId: {newProgId}");
+                TraceLogger.LogMessage("CreateDynamicDriver", $"Device type: {deviceType}, newProgId: {newProgId}");
 
                 // Configure the IP address, port number and Alpaca device number in the newly registered driver
                 Profile.SetValue(deviceType, newProgId, PROFILE_VALUE_NAME_IP_ADDRESS, hostName);
@@ -282,7 +280,7 @@ namespace ASCOM.Com
                     driverKey.SetValue($"{newProgId} Init", "True");
                 }
 
-                TL.LogMessage("OK Click", $"Returning ProgID: '{newProgId}'");
+                TraceLogger.LogMessage("OK Click", $"Returning ProgID: '{newProgId}'");
             }
             catch (Win32Exception ex) when ((uint)ex.ErrorCode == 0x80004005)
             {
@@ -291,7 +289,7 @@ namespace ASCOM.Com
             }
             catch (Exception ex)
             {
-                TL.LogMessage("CreateDynamicDriver", $"Exception: \r\n{ex}");
+                TraceLogger.LogMessage("CreateDynamicDriver", $"Exception: \r\n{ex}");
             }
             return newProgId;
         }
@@ -311,12 +309,12 @@ namespace ASCOM.Com
                 deviceNumber += 1;
                 newProgId = $"{DRIVER_PROGID_BASE}{deviceNumber}.{Devices.DeviceTypeToString(deviceType)}";
                 typeFromProgId = Type.GetTypeFromProgID(newProgId);
-                TL.LogMessage("CreateAlpacaClient", $"Testing ProgID: {newProgId} Type name: {typeFromProgId?.Name}");
+                TraceLogger.LogMessage("CreateAlpacaClient", $"Testing ProgID: {newProgId} Type name: {typeFromProgId?.Name}");
             }
             while ((!(typeFromProgId == null)))// Increment the device number// Create the new ProgID to be tested// Try to get the type with the new ProgID
         ; // Loop until the returned type is null indicating that this type is not COM registered
 
-            TL.LogMessage("CreateAlpacaClient", $"Creating new ProgID: {newProgId}");
+            TraceLogger.LogMessage("CreateAlpacaClient", $"Creating new ProgID: {newProgId}");
 
             RunDynamicClientManager($@"\CreateAlpacaClient {deviceType} {deviceNumber} {newProgId} ""{deviceDescription}""");
 
@@ -337,12 +335,12 @@ namespace ASCOM.Com
             clientManagerWorkingDirectory = $@"{Environment.GetFolderPath(SpecialFolder.ProgramFilesX86)}\{ALPACA_DYNAMIC_CLIENT_MANAGER_RELATIVE_PATH}";
             clientManagerExeFile = $@"{clientManagerWorkingDirectory}\{ALPACA_DYNAMIC_CLIENT_MANAGER_EXE_NAME}";
 
-            TL.LogMessage("RunDynamicClientManager", $"Generator parameters: '{parameterString}'");
-            TL.LogMessage("RunDynamicClientManager", $"Managing drivers using the {clientManagerExeFile} executable in working directory {clientManagerWorkingDirectory}");
+            TraceLogger.LogMessage("RunDynamicClientManager", $"Generator parameters: '{parameterString}'");
+            TraceLogger.LogMessage("RunDynamicClientManager", $"Managing drivers using the {clientManagerExeFile} executable in working directory {clientManagerWorkingDirectory}");
 
             if (!File.Exists(clientManagerExeFile))
             {
-                TL.LogMessage("RunDynamicClientManager", $"ERROR - Unable to find the client generator executable at {clientManagerExeFile}, cannot create a new Alpaca client.");
+                TraceLogger.LogMessage("RunDynamicClientManager", $"ERROR - Unable to find the client generator executable at {clientManagerExeFile}, cannot create a new Alpaca client.");
                 throw new InvalidOperationException($"RunDynamicClientManager - Unable to find the client generator executable at {clientManagerExeFile}, cannot create a new Alpaca client.");
             }
 
@@ -362,7 +360,7 @@ namespace ASCOM.Com
             clientManagerProcess.Exited += new EventHandler(DriverGeneration_Complete);
 
             // Run the process
-            TL.LogMessage("RunDynamicClientManager", $"Starting driver management process");
+            TraceLogger.LogMessage("RunDynamicClientManager", $"Starting driver management process");
             clientManagerProcess.Start();
 
             // Wait for the process to complete at which point the process complete event will fire and driverGenerationComplete will be set true
@@ -372,7 +370,7 @@ namespace ASCOM.Com
             }
             while (!driverGenerationComplete);
 
-            TL.LogMessage("RunDynamicClientManager", $"Completed driver management process");
+            TraceLogger.LogMessage("RunDynamicClientManager", $"Completed driver management process");
 
             clientManagerProcess.Dispose();
         }

--- a/ASCOM.Com/Profile/Profile.cs
+++ b/ASCOM.Com/Profile/Profile.cs
@@ -1,13 +1,7 @@
-﻿using ASCOM.Com.DriverAccess;
-using Microsoft.Win32;
+﻿using Microsoft.Win32;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text.RegularExpressions;
-using System.Threading;
 using ASCOM.Common;
-using System.Xml.Linq;
 
 namespace ASCOM.Com
 {

--- a/ASCOM.Common/ASCOM.Common.Alpaca/AlpacaTools.cs
+++ b/ASCOM.Common/ASCOM.Common.Alpaca/AlpacaTools.cs
@@ -1,12 +1,8 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Data.SqlTypes;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace ASCOM.Common.Alpaca

--- a/ASCOM.Common/ASCOM.Common.Alpaca/Discovery/Entity Classes/AlpacaConfiguredDevice.cs
+++ b/ASCOM.Common/ASCOM.Common.Alpaca/Discovery/Entity Classes/AlpacaConfiguredDevice.cs
@@ -1,6 +1,4 @@
-﻿using ASCOM.Common;
-
-namespace ASCOM.Alpaca.Discovery
+﻿namespace ASCOM.Alpaca.Discovery
 {
     /// <summary>
     /// Returns an array of device description objects, providing unique information for each served device, enabling them to be accessed through the Alpaca Device API.

--- a/ASCOM.Common/ASCOM.Common.Alpaca/NameSpaceDoc.cs
+++ b/ASCOM.Common/ASCOM.Common.Alpaca/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Common.Alpaca
+﻿namespace ASCOM.Common.Alpaca
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Common/ASCOM.Common.Alpaca/Structs/ArrayMetadataV1.cs
+++ b/ASCOM.Common/ASCOM.Common.Alpaca/Structs/ArrayMetadataV1.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using System.Runtime.InteropServices;
 
 namespace ASCOM.Common.Alpaca
 {

--- a/ASCOM.Common/ASCOM.Common.Com/NameSpaceDoc.cs
+++ b/ASCOM.Common/ASCOM.Common.Com/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Common.Com
+﻿namespace ASCOM.Common.Com
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Common/ASCOM.Common.DeviceInterfaces/NameSpaceDoc.cs
+++ b/ASCOM.Common/ASCOM.Common.DeviceInterfaces/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Common.DeviceInterfaces
+﻿namespace ASCOM.Common.DeviceInterfaces
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Common/ASCOM.Common.Helpers/NameSpaceDoc.cs
+++ b/ASCOM.Common/ASCOM.Common.Helpers/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Common.Helpers
+﻿namespace ASCOM.Common.Helpers
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Common/ASCOM.Common.Interfaces/ITraceLogger.cs
+++ b/ASCOM.Common/ASCOM.Common.Interfaces/ITraceLogger.cs
@@ -1,0 +1,15 @@
+﻿namespace ASCOM.Common.Interfaces
+{
+    /// <summary>
+    /// Trace logger interface, extends ILogger for component-specific logging
+    /// </summary>
+    public interface ITraceLogger : ILogger
+    {
+        /// <summary>
+        /// Write a message to the trace log
+        /// </summary>
+        /// <param name="identifier">Member name or function name.</param>
+        /// <param name="message">Message text</param>
+        void LogMessage(string identifier, string message);
+    }
+}

--- a/ASCOM.Common/ASCOM.Common.Interfaces/NameSpaceDoc.cs
+++ b/ASCOM.Common/ASCOM.Common.Interfaces/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Common.Interfaces
+﻿namespace ASCOM.Common.Interfaces
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Common/Devices/Devices.cs
+++ b/ASCOM.Common/Devices/Devices.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace ASCOM.Common
 {

--- a/ASCOM.Common/NameSpaceDoc.cs
+++ b/ASCOM.Common/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Common
+﻿namespace ASCOM.Common
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Common/NullLogger.cs
+++ b/ASCOM.Common/NullLogger.cs
@@ -1,0 +1,24 @@
+﻿using ASCOM.Common.Interfaces;
+
+namespace ASCOM.Common
+{
+    public class NullLogger : ITraceLogger
+    {
+        public LogLevel LoggingLevel { get; private set; }
+
+        public void SetMinimumLoggingLevel(LogLevel level)
+        {
+            LoggingLevel = level;
+        }
+
+        public void Log(LogLevel level, string message)
+        {
+            // NullLogger does not log anything
+        }
+
+        public void LogMessage(string identifier, string message)
+        {
+            // NullLogger does not log anything
+        }
+    }
+}

--- a/ASCOM.Tools/NameSpaceDoc.cs
+++ b/ASCOM.Tools/NameSpaceDoc.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Tools
+﻿namespace ASCOM.Tools
 {
     // Dummy class to hold comments that appear at the namespace level in the compiled Help file
 

--- a/ASCOM.Tools/Sofa.cs
+++ b/ASCOM.Tools/Sofa.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
-using System.Runtime.InteropServices;
-using System.Text;
+﻿using System.Runtime.InteropServices;
 
 namespace ASCOM.Tools
 {

--- a/ASCOM.Tools/TraceLogger.cs
+++ b/ASCOM.Tools/TraceLogger.cs
@@ -21,7 +21,7 @@ namespace ASCOM.Tools
     /// and fractional second at the time that the message was logged, Identifier is the supplied identifier (usually the subroutine,
     /// function, property or method from which the message is sent) and Message is the message to be logged.</para>
     ///</remarks>
-    public class TraceLogger : IDisposable, ILogger
+    public class TraceLogger : IDisposable, ITraceLogger, ILogger
     {
         // Configuration constants
         private const int IDENTIFIER_WIDTH_DEFAULT = 25;

--- a/test/ASCOMStandard.Tests/Alpaca/AlpacaDiscovery.cs
+++ b/test/ASCOMStandard.Tests/Alpaca/AlpacaDiscovery.cs
@@ -3,14 +3,8 @@ using ASCOM.Alpaca.Discovery;
 using ASCOM.Common;
 using ASCOM.Common.Alpaca;
 using ASCOM.Tools;
-using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 using Xunit;
-using static ASCOM.Common.Devices;
 
 namespace ASCOM.Alpaca.Tests.Alpaca
 {

--- a/test/ASCOMStandard.Tests/Devices/DeviceTypeTests.cs
+++ b/test/ASCOMStandard.Tests/Devices/DeviceTypeTests.cs
@@ -1,9 +1,4 @@
 ﻿using ASCOM.Common;
-using ASCOM.Common.Alpaca;
-using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 using static ASCOM.Common.Devices;
 

--- a/test/ASCOMStandard.Tests/Extensions.cs
+++ b/test/ASCOMStandard.Tests/Extensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace ASCOM.Alpaca.Tests
 {

--- a/test/ASCOMStandard.Tests/ImageArray/ImageArray2DObjectByte.cs
+++ b/test/ASCOMStandard.Tests/ImageArray/ImageArray2DObjectByte.cs
@@ -1,8 +1,6 @@
 ﻿using ASCOM.Common.Alpaca;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/ASCOMStandard.Tests/ImageArray/ImageArray2DObjectInt16.cs
+++ b/test/ASCOMStandard.Tests/ImageArray/ImageArray2DObjectInt16.cs
@@ -1,8 +1,6 @@
 ﻿using ASCOM.Common.Alpaca;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Text;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/test/ASCOMStandard.Tests/ImageArray/ImageArray2DObjectUInt16.cs
+++ b/test/ASCOMStandard.Tests/ImageArray/ImageArray2DObjectUInt16.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace ASCOM.Alpaca.Tests.ImageArray
+﻿namespace ASCOM.Alpaca.Tests.ImageArray
 {
     internal class ImageArray2DObjectUInt16
     {

--- a/test/ASCOMStandard.Tests/ImageArray/ImageArrayTests.cs
+++ b/test/ASCOMStandard.Tests/ImageArray/ImageArrayTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 using ASCOM.Common.Alpaca;
 using Xunit.Abstractions;
-using System.Runtime.InteropServices;
 using System.Diagnostics;
 using System.Threading.Tasks;
 

--- a/test/ASCOMStandard.Tests/PlatformUtilities/PlatformUtilitiesTests.cs
+++ b/test/ASCOMStandard.Tests/PlatformUtilities/PlatformUtilitiesTests.cs
@@ -1,7 +1,5 @@
 ﻿using ASCOM.Common;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace ASCOM.Alpaca.Tests.PlatformUtilities

--- a/test/ASCOMStandard.Tests/Profile/IsRegisteredTests.cs
+++ b/test/ASCOMStandard.Tests/Profile/IsRegisteredTests.cs
@@ -1,8 +1,4 @@
-﻿using ASCOM.Common.Alpaca;
-using Microsoft.Win32;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Microsoft.Win32;
 using Xunit;
 using ASCOM.Common;
 

--- a/test/ASCOMStandard.Tests/Profile/ProfileDeleteTests.cs
+++ b/test/ASCOMStandard.Tests/Profile/ProfileDeleteTests.cs
@@ -1,7 +1,4 @@
 ﻿using ASCOM.Common;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace ASCOM.Alpaca.Tests.Profile

--- a/test/ASCOMStandard.Tests/Profile/ProfileReadTests.cs
+++ b/test/ASCOMStandard.Tests/Profile/ProfileReadTests.cs
@@ -1,7 +1,5 @@
 ﻿using ASCOM.Common;
-using System;
 using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace ASCOM.Alpaca.Tests.Profile

--- a/test/ASCOMStandard.Tests/Profile/ProfileWriteTests.cs
+++ b/test/ASCOMStandard.Tests/Profile/ProfileWriteTests.cs
@@ -1,7 +1,4 @@
 ﻿using ASCOM.Common;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace ASCOM.Alpaca.Tests.Profile

--- a/test/ASCOMStandard.Tests/Profile/SubKeyTests.cs
+++ b/test/ASCOMStandard.Tests/Profile/SubKeyTests.cs
@@ -1,7 +1,4 @@
 ﻿using ASCOM.Common;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using Xunit;
 
 namespace ASCOM.Alpaca.Tests.Profile

--- a/test/ASCOMStandard.Tests/Profile/Test.cs
+++ b/test/ASCOMStandard.Tests/Profile/Test.cs
@@ -1,10 +1,7 @@
 ﻿using ASCOM.Common;
 using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
-using System.Xml.Linq;
 
 namespace ASCOM.Alpaca.Tests.Profile
 {

--- a/test/ASCOMStandard.Tests/SOFA/SofaTests.cs
+++ b/test/ASCOMStandard.Tests/SOFA/SofaTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Xunit;
+﻿using Xunit;
 using ASCOM.Tools;
 
 namespace ASCOM.Alpaca.Tests.SOFA

--- a/test/ASCOMStandard.Tests/TestSupport.cs
+++ b/test/ASCOMStandard.Tests/TestSupport.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.VisualStudio.TestPlatform.Utilities;
-using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System;
 using Xunit.Abstractions;
 
 namespace ASCOM.Alpaca.Tests

--- a/test/ASCOMStandard.Tests/Transform/TransformFunctionalTests.cs
+++ b/test/ASCOMStandard.Tests/Transform/TransformFunctionalTests.cs
@@ -1,6 +1,5 @@
 ﻿using ASCOM.Tools;
 using System;
-using System.IO;
 using Xunit;
 
 namespace ASCOM.Alpaca.Tests.TransformTests

--- a/test/ASCOMStandard.Tests/Transform/TransformLoggerTests.cs
+++ b/test/ASCOMStandard.Tests/Transform/TransformLoggerTests.cs
@@ -1,6 +1,4 @@
 ﻿using ASCOM.Tools;
-using System;
-using System.IO;
 using Xunit;
 
 namespace ASCOM.Alpaca.Tests.TransformTests


### PR DESCRIPTION
Related to #23, here is a PR that refactors (trace)logger usage to
1. allow custom logger implementations
2. remove ASCOM.Tools (with Sofa library and hard-coded logger) depdency in Alpaca/Com packages

_Note: When I removed unused usings after refactoring, I noticed a lot of unused using statements that are not related to my changes. They are still part of this PR. If you want me to exclude those changes let me know. I suspect that they are orphaned code from earlier work._