### PR TITLE
Fix NullReferenceException in Profile.GetDrivers on systems with no ASCOM Platform installed

### DIFF
--- a/ASCOM.Com/Profile/Profile.cs
+++ b/ASCOM.Com/Profile/Profile.cs
@@ -32,6 +32,8 @@ namespace ASCOM.Com
             {
                 using (var ASCOMKeys = localmachine32.OpenSubKey($"SOFTWARE\\ASCOM\\{Devices.DeviceTypeToString(deviceType)} Drivers", false))
                 {
+                    if (ASCOMKeys == null)
+                        return Drivers;
                     foreach (var key in ASCOMKeys.GetSubKeyNames())
                     {
                         string name = string.Empty;


### PR DESCRIPTION
If the required registry key is not present, return an empty list of drivers (as, for example, on a system without the ASCOM Platform installed)

Fixes https://github.com/ASCOMInitiative/ASCOMLibrary/issues/27