### PR TITLE
Workaround regression with existing driver compared to ASCOM platform - handle slight out-of-spec response to Camera.Gains in the same way as ASCOM Platform

### DIFF
--- a/ASCOM.Com/ASCOM.Com.DriverAccess/Camera.cs
+++ b/ASCOM.Com/ASCOM.Com.DriverAccess/Camera.cs
@@ -854,7 +854,9 @@ namespace ASCOM.Com.DriverAccess
                 {
                     throw new ASCOM.NotImplementedException("Gains is only supported by Interface Versions 2 and above.");
                 }
-                return (Device.Gains as IEnumerable).Cast<string>().ToList();
+                // ASCOM.DSLR driver returns an array of integers, not strings. ASCOM Platform hid this issue by converting to strings
+                // so this code should forgive the same issue by converting the contents of whatever is returned by the underlying driver to strings
+                return (Device.Gains as IEnumerable).OfType<object>().Select(x => x.ToString()).ToList();
             }
         }
 


### PR DESCRIPTION
ASCOM.DSLR driver returns (incorrectly) an array of integers for Gains. ASCOM Platform dealt with this issue with no error, so ASCOM Library should too, otherwise drivers break when switching to ASCOM Library

Fixes https://github.com/ASCOMInitiative/ASCOMLibrary/issues/28